### PR TITLE
httpx does not follow redirects by default.

### DIFF
--- a/ch04-language-foundations/async/async_scrape/program.py
+++ b/ch04-language-foundations/async/async_scrape/program.py
@@ -16,7 +16,7 @@ async def get_html(episode_number: int) -> str:
     url = f'https://talkpython.fm/{episode_number}'
 
     async with httpx.AsyncClient() as client:
-        resp = await client.get(url)
+        resp = await client.get(url, follow_redirects=True)
         resp.raise_for_status()
 
         return resp.text


### PR DESCRIPTION
The old URL's now have a redirect.  For example the URL `https://talkpython.fm/270` is redirected to `https://talkpython.fm/episodes/show/270/python-in-supply-chains-oil-rigs-rockets-and-lettuce`. By default httpx does not follow redirects. To enable redirect's we need to add the follow_redirects=True flag to the httpx.get call.